### PR TITLE
Add support for blank images

### DIFF
--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -37,14 +37,17 @@ const getImageType = (densities: Record<number, ImgSrc>): string => {
   return densities[keys[keys.length - 1]].format;
 };
 
+const getBlankImage = () => {
+  return 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+};
+
 const buildSources = (
+  webp: boolean,
   type: Record<number | string, Record<number, ImgSrc>>,
   sizes: Array<number | string>,
   breakpoints?: number[],
 ): ReactElement[] => {
   return sizes.map((size, i) => {
-    const densities = type[size];
-    const imageType = `image/${getImageType(densities)}`;
     let media;
 
     if (size === 'original' || sizes.length === 0 || !breakpoints || i > breakpoints.length) {
@@ -59,6 +62,14 @@ const buildSources = (
     } else {
       media = `(min-width: ${breakpoints[i - 1] + 1}px) and (max-width: ${breakpoints[i]}px)`;
     }
+
+    if (size === 0) {
+      if (webp) return <React.Fragment key={`fragment/${media}`} />;
+      return <source key={`blank/${media}`} srcSet={getBlankImage()} media={media} />;
+    }
+
+    const densities = type[size];
+    const imageType = `image/${getImageType(densities)}`;
 
     return <source key={`${imageType}/${size}`} type={imageType} srcSet={buildSrcSet(densities)} media={media} />;
   });
@@ -127,11 +138,13 @@ const Img = ({
     <picture>
       {rawSrc.webp &&
         buildSources(
+          true,
           rawSrc.webp,
           sizes || ((Object.keys(rawSrc.webp) as unknown) as (number | string)[]),
           breakpoints || sizes,
         )}
       {buildSources(
+        false,
         rawSrc.fallback,
         sizes || ((Object.keys(rawSrc.fallback) as unknown) as (number | string)[]),
         breakpoints || sizes,

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -70,8 +70,9 @@ const buildSources = (
 
     const densities = type[size];
     const imageType = `image/${getImageType(densities)}`;
+    const key = `${imageType}/${media || 'original'}`;
 
-    return <source key={`${imageType}/${size}`} type={imageType} srcSet={buildSrcSet(densities)} media={media} />;
+    return <source key={key} type={imageType} srcSet={buildSrcSet(densities)} media={media} />;
   });
 };
 

--- a/src/plugin/transform/img.ts
+++ b/src/plugin/transform/img.ts
@@ -133,7 +133,7 @@ const buildRawSrcAttribute = (
         (config.densities || [1]).forEach((density) => {
           const sizeQuery: Record<string, string> = {
             ...query,
-            ...(typeof size === 'number' ? { width: `${size * density}` } : {}),
+            ...(typeof size === 'number' && size > 0 ? { width: `${size * density}` } : {}),
           };
 
           sizeProperties.push(


### PR DESCRIPTION
When the `size` prop is 0 a blank image `data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==` is used to prevent the browser from fetching the image.