### PR TITLE
Create option to automatically add width and height to img

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ export default () => (
 | inline | | `boolean` | If true, the image will get forced to an inline data-uri (e.g. `data:image/png;base64,...`). |
 | url | | `boolean` | If true, the image will get forced to be referenced with an url, even if it is a small image and would get inlined by default. |
 | original | | `boolean` | If true, the image will not get optimized (but still resized if the `sizes` property is present). |
+| withDimensions | | `boolean` | If true, `width` and `height` attributes will be added automatically to the `<img>` tag with values extracted from the original image. These values will always be overwritten when explicitly specified. |
 | type | | `string` | So you don't have to repeat yourself by setting the same sizes or other properties on many images, specify the image type which equals to one in your [global image config](#global-image-config). |
 | *anything else* | | `ImgHTMLAttributes` | All other properties will be directly passed to the `<img>` tag. So it would for example be possible to use native lazy-loading with `loading="lazy"`. |
 

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -9,6 +9,7 @@ export interface ImgProps
   inline?: boolean;
   url?: boolean;
   original?: boolean;
+  withDimensions?: boolean;
   sizes?: number[];
   densities?: number[];
   breakpoints?: number[];
@@ -99,6 +100,7 @@ const Img = ({
   sizes,
   densities,
   breakpoints,
+  withDimensions,
   style,
   ...props
 }: ImgProps): ReactElement | null => {
@@ -114,13 +116,21 @@ const Img = ({
   // find fallback image
   const fallbackImage = findFallbackImage(src, rawSrc);
 
+  let dimensions;
+  if (withDimensions === true) {
+    dimensions = {
+      width: fallbackImage.width,
+      height: fallbackImage.height,
+    };
+  }
+
   // return normal image tag if only 1 version is needed
   if (
     !rawSrc.webp &&
     Object.keys(rawSrc.fallback).length === 1 &&
     Object.keys(rawSrc.fallback[(Object.keys(rawSrc.fallback)[0] as unknown) as number]).length === 1
   ) {
-    return <img src={fallbackImage.toString()} {...imgProps} style={styles} />;
+    return <img src={fallbackImage.toString()} {...dimensions} {...imgProps} style={styles} />;
   }
 
   return (
@@ -136,7 +146,7 @@ const Img = ({
         sizes || ((Object.keys(rawSrc.fallback) as unknown) as (number | string)[]),
         breakpoints || sizes,
       )}
-      <img src={fallbackImage.toString()} {...imgProps} style={styles} />
+      <img src={fallbackImage.toString()} {...dimensions} {...imgProps} style={styles} />
     </picture>
   );
 };

--- a/src/plugin/imageConfig.ts
+++ b/src/plugin/imageConfig.ts
@@ -8,6 +8,7 @@ export interface ImageConfig {
   inline?: boolean;
   url?: boolean;
   original?: boolean;
+  withDimensions?: boolean;
 }
 
 export interface GlobalConfig {

--- a/src/plugin/transform/img.ts
+++ b/src/plugin/transform/img.ts
@@ -28,8 +28,8 @@ const buildConfig = (types: Babel['types'], path: NodePath<JSXElement>): ImageCo
     config = { ...config, ...globalImageConfig.types[type] };
   }
 
-  // check boolean attributes: webp, inline, url, original
-  ['webp', 'inline', 'url', 'original'].forEach((attr) => {
+  // check boolean attributes: webp, inline, url, original, withDimensions
+  ['webp', 'inline', 'url', 'original', 'withDimensions'].forEach((attr) => {
     const value = getBooleanAttribute(path, attr);
 
     if (typeof value !== 'undefined') {


### PR DESCRIPTION
Since we have these values i thought it my be useful to add them automatically to `<img>`. I know that sources will most likely have different values, but the ratio should be the same. Also when browsers will add support for `width` and `height` in sources we can easily extend this.

I created another pull request because https://github.com/cyrilwanner/react-optimized-image/pull/11 has unsigned commits.